### PR TITLE
Change CSS

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -8,7 +8,7 @@ templateClass: tmpl-post
 {%- for tag in tags | filterTagList -%}
 {%- set tagUrl %}/tags/{{ tag | slug }}/{% endset -%}
 <a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a>
-{%- endfor %}
+{% endfor %}
 
 {{ content | safe }}
 

--- a/css/index.css
+++ b/css/index.css
@@ -178,15 +178,6 @@ a[href].post-tag:focus {
   align-self: center;
 }
 
-/* Warning */
-.warning {
-  background-color: #ffc;
-  padding: 1em 0.625em; /* 16px 10px /16 */
-}
-.warning ol:only-child {
-  margin: 0;
-}
-
 /* Direct Links / Markdown Headers */
 .direct-link {
   font-family: sans-serif;

--- a/css/index.css
+++ b/css/index.css
@@ -1,11 +1,6 @@
 /* Colors */
 :root {
-  --lightgray: #e0e0e0;
-  --gray: #C0C0C0;
-  --darkgray: #333;
-  --navy: #17050F;
-  --blue: #082840;
-  --white: #fff;
+color-scheme: dark light;
 }
 
 /* Global stylesheet */
@@ -18,8 +13,6 @@ body {
   padding: 0;
   margin: 0;
   font-family: -apple-system, system-ui, sans-serif;
-  color: var(--darkgray);
-  background-color: var(--white);
 }
 p:last-child {
   margin-bottom: 0;
@@ -33,12 +26,6 @@ p,
 .tmpl-post li {
   line-height: 1.45;
 }
-a[href] {
-  color: var(--blue);
-}
-a[href]:visited {
-  color: var(--navy);
-}
 main {
   padding: 1rem;
 }
@@ -46,7 +33,7 @@ main :first-child {
   margin-top: 0;
 }
 header {
-  border-bottom: 1px dashed var(--lightgray);
+  border-bottom: 1px dashed;
 }
 header:after {
   content: "";
@@ -83,7 +70,7 @@ pre {
   hyphens: none;
   padding: 1em;
   margin: .5em 0;
-  background-color: #f6f6f6;
+  background-color: canvas;
 }
 code {
   word-break: break-all;
@@ -141,7 +128,6 @@ code {
 .postlist-date,
 .postlist-item:before {
   font-size: 0.8125em; /* 13px /16 */
-  color: var(--darkgray);
 }
 .postlist-date {
   word-spacing: -0.5px;
@@ -173,19 +159,20 @@ code {
   margin-left: 0.6666666666667em; /* 8px /12 */
   margin-top: 0.5em; /* 6px /12 */
   margin-bottom: 0.5em; /* 6px /12 */
-  color: var(--darkgray);
-  border: 1px solid var(--gray);
+  border: 1px solid;
   border-radius: 0.25em; /* 3px /12 */
   text-decoration: none;
   line-height: 1.8;
 }
 a[href].post-tag,
 a[href].post-tag:visited {
-  color: inherit;
+  color: canvas;
+  background-color: canvastext;
 }
 a[href].post-tag:hover,
 a[href].post-tag:focus {
-  background-color: var(--lightgray);
+  color: canvastext;
+  background-color: canvas;
 }
 .postlist-item > .post-tag {
   align-self: center;
@@ -206,14 +193,4 @@ a[href].post-tag:focus {
   text-decoration: none;
   font-style: normal;
   margin-left: .1em;
-}
-a[href].direct-link,
-a[href].direct-link:visited {
-  color: transparent;
-}
-a[href].direct-link:focus,
-a[href].direct-link:focus:visited,
-:hover > a[href].direct-link,
-:hover > a[href].direct-link:visited {
-  color: #aaa;
 }

--- a/css/index.css
+++ b/css/index.css
@@ -149,11 +149,13 @@ code {
 
 
 /* Tags */
+.post-tag:before {
+  content: "\23";
+}
 .post-tag {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  text-transform: uppercase;
   font-size: 0.75em; /* 12px /16 */
   padding: 0.08333333333333em 0.3333333333333em; /* 1px 4px /12 */
   margin-left: 0.6666666666667em; /* 8px /12 */


### PR DESCRIPTION
[Allow trailing whitespace in tag list](https://github.com/agvbergin/agvbergin.net/commit/9f70d30f33549a0976a2442eba367dcde2458598) adds whitespace after tags so they don't run into each other on blog post pages. I do not know if removing the `-` from the Nunjucks tag was the right approach because I don't yet understand the docs. Might revisit.

[Use user agent defaults for color](https://github.com/agvbergin/agvbergin.net/commit/35e6fdeac606d305ebbcdc8f6104fe769474e65c) makes dark mode possible [with a single line of CSS](https://web.dev/color-scheme/). Works in Chrome and Firefox, but not Safari.

[Remove CSS for base blog warning](https://github.com/agvbergin/agvbergin.net/commit/831462ce8ef5ba455d234b5e42864226507c5427) as not needed.

[Make tag links lower case, insert hash before](https://github.com/agvbergin/agvbergin.net/commit/3fd6b68716176a81a513d4de9adc627a9e63f98c).
