### PR TITLE
Don't make anchors for h1

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -77,7 +77,7 @@ module.exports = function (eleventyConfig) {
       placement: "after",
       class: "direct-link",
       symbol: "#",
-      level: [1, 2, 3, 4],
+      level: [2, 3, 4],
     }),
     slugify: eleventyConfig.getFilter("slug"),
   });


### PR DESCRIPTION
[Don't make anchors for h1](https://github.com/agvbergin/agvbergin.net/commit/db4989ac83e003bfd43b7d3d0308e68badeca508) update Eleventy config to not make anchors on first level headings.